### PR TITLE
Menu Navigation reworking

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -48,7 +48,7 @@ dlf_fast_console() {
 # $1 is the msg
 msgbox() {
     log "MessageBox >> ""$1"
-    whiptail --backtitle "$( window_title )" --msgbox "$1" 0 0 0 
+    whiptail --backtitle "$( window_title )" --msgbox "$1" 0 0 0
 }
 
 # $1 is the product

--- a/common.sh
+++ b/common.sh
@@ -92,30 +92,30 @@ install_prereqs() {
     case "$DISTRO" in
         "ubuntu")
                 install_pg_repo
-                if [ "$[$(date +%s) - $(stat -c %Z /var/lib/apt/periodic/update-success-stamp)]" -ge 600 ]; then
+                if [ "$[$(date +%s) - $(stat -c %Z /var/lib/apt/periodic/update-success-stamp)]" -ge 3600 ]; then
                   sudo apt-get update
                 else
-                  log "Skipping apt-get update as it was run less than 10 minutes ago..."
+                  log "Skipping apt-get update as it was run less than an hour ago..."
                 fi
                 sudo apt-get -y install axel git whiptail unzip bzip2 wget curl build-essential libssl-dev postgresql-client-9.3 cups python-software-properties openssl libnet-ssleay-perl libauthen-pam-perl libpam-runtime libio-pty-perl perl libavahi-compat-libdnssd-dev python 
                 RET=$?
-                if [ $RET -eq 1 ]; then
+                if [ $RET -ne 0 ]; then
                     msgbox "Something went wrong installing prerequisites for $DISTRO. Check the output for more info. "
                     do_exit
                 fi
                 ;;
         "debian")
                 install_pg_repo
-                if [ "$[$(date +%s) - $(stat -c %Z /var/lib/apt/periodic/update-success-stamp)]" -ge 600 ]; then
+                if [ "$[$(date +%s) - $(stat -c %Z /var/lib/apt/periodic/update-success-stamp)]" -ge 3600 ]; then
                   sudo apt-get update
                 else
-                  log "Skipping apt-get update as it was run less than 10 minutes ago..."
+                  log "Skipping apt-get update as it was run less than an hour ago..."
                 fi
                 sudo apt-get -y install python-software-properties software-properties-common
                 sudo add-apt-repository -y "deb http://ftp.debian.org/debian wheezy-backports main"
                 sudo apt-get update && sudo apt-get -y install axel git whiptail unzip bzip2 wget curl build-essential libssl-dev postgresql-client-9.3
                 RET=$?
-                if [ $RET -eq 1 ]; then
+                if [ $RET -ne 0 ]; then
                     msgbox "Something went wrong installing prerequisites for $DISTRO. Check the output for more info. "
                     do_exit
                 fi

--- a/database.sh
+++ b/database.sh
@@ -5,7 +5,7 @@ database_menu() {
     log "Opened database menu"
 
     while true; do
-        DBM=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Database\ Menu )" 15 60 8 --cancel-button "Exit" --ok-button "Select" \
+        DBM=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Database\ Menu )" 15 60 8 --cancel-button "Cancel" --ok-button "Select" \
             "1" "Set database info" \
             "2" "Clear database info" \
             "3" "Backup Database" \
@@ -22,12 +22,11 @@ database_menu() {
             3>&1 1>&2 2>&3)
 
         RET=$?
-
         if [ $RET -ne 0 ]; then
             break
         else
             case "$DBM" in
-            "1") log_choice set_database_info ;;
+            "1") log_choice clear_database_info && log_choice check_database_info ;;
             "2") log_choice clear_database_info ;;
             "3") log_choice backup_database ;;
             "4") log_choice list_databases ;;
@@ -58,7 +57,56 @@ download_demo() {
     else
         MODE="auto"
     fi
+
+    if [ -z $4 ] && [ -z "$DBTYPE" ]; then
+        DBTYPE="demo"
+    else
+        DBTYPE=$4
+    fi
     
+    if [ -z $3 ]; then
+        MENUVER=$(whiptail --backtitle "$( window_title )" --menu "Choose Version" 15 60 7 --cancel-button "Cancel" --ok-button "Select" \
+                "1" "PostBooks 4.8.1 Demo" \
+                "2" "PostBooks 4.8.1 Empty" \
+                "3" "PostBooks 4.8.1 QuickStart" \
+                "4" "PostBooks 4.9.1 Demo" \
+                "5" "PostBooks 4.9.1 Empty" \
+                "6" "PostBooks 4.9.1 QuickStart" \
+                "7" "Return to database menu" \
+                3>&1 1>&2 2>&3)
+
+        RET=$?
+
+        if [ $RET -ne 0 ]; then
+            return $RET
+        else
+            case "$MENUVER" in
+            "1") VERSION=4.8.1 
+                   DBTYPE="demo"
+                   ;;
+            "2") VERSION=4.8.1
+                   DBTYPE="empty"
+                   ;;
+            "3") VERSION=4.8.1
+                   DBTYPE="quickstart"
+                   ;;
+            "4") VERSION=4.9.1
+                   DBTYPE="demo"
+                   ;;
+            "5") VERSION=4.9.1
+                   DBTYPE="empty"
+                   ;;
+            "6") VERSION=4.9.1
+                   DBTYPE="quickstart"
+                   ;;
+            "7") return 0 ;;
+            *) msgbox "How did you get here?" && return 1 ;;
+            esac || return 1
+        fi
+    else
+        VERSION=$3
+    fi
+
     if [ -z $2 ]; then
         DEMODEST=$(whiptail --backtitle "$( window_title )" --inputbox "Enter the filename where you would like to save the database" 8 60 3>&1 1>&2 2>&3)
         RET=$?
@@ -69,57 +117,7 @@ download_demo() {
         DEMODEST=$2
     fi
 
-    if [ -z $4 ] && [ -z "$DBTYPE" ]; then
-        DBTYPE="demo"
-    else
-        DBTYPE=$4
-    fi
-    
-    if [ -z $3 ]; then
-        MENUVER=$(whiptail --backtitle "$( window_title )" --menu "Choose Version" 15 60 7 --cancel-button "Exit" --ok-button "Select" \
-                "1" "PostBooks 4.8.1 Demo" \
-                "2" "PostBooks 4.8.1 Empty" \
-                "3" "PostBooks 4.8.1 QuickStart" \
-                "4" "PostBooks 4.9.0 Demo" \
-                "5" "PostBooks 4.9.0 Empty" \
-                "6" "PostBooks 4.9.0 QuickStart" \
-                "7" "Return to database menu" \
-                3>&1 1>&2 2>&3)
-
-        RET=$?
-
-        if [ $RET -ne 0 ]; then
-            return 0
-        elif [ $RET -eq 0 ]; then
-            case "$MENUVER" in
-            "1") VERSION=4.8.1 
-                   DBTYPE="demo"
-                   ;;
-            "2") VERSION=4.8.1 
-                   DBTYPE="empty"
-                   ;;
-            "3") VERSION=4.8.1 
-                   DBTYPE="quickstart"
-                   ;;
-            "4") VERSION=4.9.0 
-                   DBTYPE="demo"
-                   ;;
-            "5") VERSION=4.9.0 
-                   DBTYPE="empty"
-                   ;;
-            "6") VERSION=4.9.0 
-                   DBTYPE="quickstart"
-                   ;;
-            "7") return 0 ;;
-            *) msgbox "How did you get here?" && break ;;
-            esac || break
-        fi
-    else
-        VERSION=$3
-    fi
-    
     log_arg $MODE $DEMODEST $VERSION $DBTYPE
-
 
     DB_URL="http://files.xtuple.org/$VERSION/$DBTYPE.backup"
     MD5_URL="http://files.xtuple.org/$VERSION/$DBTYPE.backup.md5sum"
@@ -136,8 +134,8 @@ download_demo() {
     VALID=`cat "$DEMODEST".md5sum | awk '{printf $1}'`
     CURRENT=`md5sum "$DEMODEST" | awk '{printf $1}'`
     if [ "$VALID" != "$CURRENT" ]; then
-        msgbox "There was an error verifying the downloaded database. Utility will now exit."
-        do_exit
+        msgbox "There was an error verifying the downloaded database."
+        return 1
     fi
 
     if [ $MODE = "manual" ]; then
@@ -149,17 +147,18 @@ download_demo() {
             fi
             export PGDATABASE=$DEST
             log "Creating database $DEST from file $DEMODEST"
-            restore_database $DEMODEST $DEST
+            log_exec restore_database $DEMODEST $DEST
             RET=$?
             if [ $RET -ne 0 ]; then
-                msgbox "Something has gone wrong. Check output and correct any issues."
-                do_exit
+                msgbox "Something has gone wrong. Check log and correct any issues."
+                return 1
             else
                 msgbox "Database $DEST successfully restored from file $DEMODEST"
                 return 0
             fi
         else
             log "Exiting without restoring database."
+            return 0
         fi
     fi
 
@@ -167,13 +166,12 @@ download_demo() {
 
 download_latest_demo() {
 
-    log_arg
     VERSION="$( latest_version db )" 
     log "Determined latest database version to be $VERSION"
 
     if [ -z "$VERSION" ]; then
         msgbox "Could not determine latest database version"
-        do_exit
+        return 1
     fi
 
     if [ -z $DEMODEST ]; then
@@ -204,11 +202,11 @@ download_latest_demo() {
             if [ $RET -ne 0 ]; then
                 return 0
             fi
-            restore_database $DEMODEST $DEST
+            log_exec restore_database $DEMODEST $DEST
             RET=$?
             if [ $RET -ne 0 ]; then
-                msgbox "Something has gone wrong. Check output and correct any issues."
-                do_exit
+                msgbox "Something has gone wrong. Check log and correct any issues, typically warnings can be ignored."
+                return $RET
             else
                 msgbox "Database $DEST successfully restored from file $DEMODEST"
                 return 0
@@ -255,8 +253,8 @@ backup_database() {
     pg_dump --username "$PGUSER" --port "$PGPORT" --host "$PGHOST" --format custom  --file "$DEST" "$SOURCE"
     RET=$?
     if [ $RET -ne 0 ]; then
-        msgbox "Something has gone wrong. Check output and correct any issues."
-        do_exit
+        msgbox "Something has gone wrong. Check log and correct any issues."
+        return $RET
     else
         msgbox "Database $SOURCE successfully backed up to $DEST"
         return 0
@@ -270,7 +268,7 @@ restore_database() {
     check_database_info
     RET=$?
     if [ $RET -ne 0 ]; then
-        return 0
+        return $RET
     fi
 
     if [ -z $2 ]; then
@@ -287,15 +285,15 @@ restore_database() {
     log_exec psql -h $PGHOST -p $PGPORT -U $PGUSER postgres -q -c "CREATE DATABASE "$DEST" OWNER admin"
     RET=$?
     if [ $RET -ne 0 ]; then
-        msgbox "Something has gone wrong. Check output and correct any issues."
-        do_exit
+        msgbox "Something has gone wrong. Check log and correct any issues."
+        return $RET
     else
         log "Restoring database $DEST from file $1 on server $PGHOST:$PGPORT"
         log_exec pg_restore --username "$PGUSER" --port "$PGPORT" --host "$PGHOST" --dbname "$DEST" "$1"
         RET=$?
         if [ $RET -ne 0 ]; then
             msgbox "Something has gone wrong. Check output and correct any issues."
-            do_exit
+            return $RET
         else
             return 0
         fi
@@ -321,13 +319,13 @@ carve_pilot() {
          done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
          if [ -z "$DATABASES" ]; then
             msgbox "No databases detected on this system"
-            return 0
+            return 1
         fi
 
         SOURCE=$(whiptail --title "PostgreSQL Databases" --menu "Select database to use as source for pilot" 16 60 5 "${DATABASES[@]}" --notags 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
-            return 0
+            return $RET
         fi
     else
         SOURCE="$1"
@@ -337,7 +335,7 @@ carve_pilot() {
         PILOT=$(whiptail --backtitle "$( window_title )" --inputbox "Enter new name of database" 8 60 "" 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
-            return 0
+            return $RET
         fi
     else
         PILOT="$2"
@@ -354,7 +352,7 @@ carve_pilot() {
         if [ $RET -ne 0 ]; then
             msgbox "Something has gone wrong. Check output and correct any issues."
             restore_connect_priv $SOURCE
-            do_exit
+            return $RET
         else
             restore_connect_priv $SOURCE
             restore_connect_priv $PILOT
@@ -365,7 +363,6 @@ carve_pilot() {
 
 create_database_from_file() {
 
-    log_arg
     check_database_info
     RET=$?
     if [ $RET -ne 0 ]; then
@@ -393,8 +390,8 @@ create_database_from_file() {
         restore_database $SOURCE $PILOT
         RET=$?
         if [ $RET -ne 0 ]; then
-            msgbox "Something has gone wrong. Check output and correct any issues."
-            do_exit
+            msgbox "Something has gone wrong. Check log and correct any issues."
+            $RET
         else
             msgbox "Database "$PILOT" has been created"
         fi
@@ -404,16 +401,18 @@ create_database_from_file() {
 
 list_databases() {
 
-    log_arg
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     DATABASES=()
 
     while read -r line; do
         DATABASES+=("$line" "$line")
-    #done < <( su - postgres -c "psql -l -t | cut -d'|' -f1 | sed -e 's/ //g' -e '/^$/d'" )
-     done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
-     if [ -z "$DATABASES" ]; then
+    done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
+    if [ -z "$DATABASES" ]; then
         msgbox "No databases detected on this system"
         return 0
     fi
@@ -424,14 +423,18 @@ list_databases() {
 drop_database_menu() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     DATABASES=()
 
     while read -r line; do
         DATABASES+=("$line" "$line")
-    #done < <( su - postgres -c "psql -l -t | cut -d'|' -f1 | sed -e 's/ //g' -e '/^$/d'" )
-     done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
-     if [ -z "$DATABASES" ]; then
+            done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
+    
+    if [ -z "$DATABASES" ]; then
         msgbox "No databases detected on this system"
         return 0
     fi
@@ -439,7 +442,7 @@ drop_database_menu() {
     DATABASE=$(whiptail --title "PostgreSQL Databases" --menu "Select database to drop" 16 60 5 "${DATABASES[@]}" --notags 3>&1 1>&2 2>&3)
     RET=$?
     if [ $RET -ne 0 ]; then
-        return 0
+        return $RET
     fi
 
     drop_database "$DATABASE"
@@ -451,29 +454,33 @@ drop_database_menu() {
 drop_database() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     if [ -z "$1" ]; then
         POSTNAME=$(whiptail --backtitle "$( window_title )" --inputbox "Enter name of database to drop" 8 60 "" 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
-            return 0
+            return $RET
         fi
     else
         POSTNAME="$1"
     fi
     log_arg $POSTNAME
 
-    if (whiptail --title "Are you sure?" --yesno "Completely remove database $POSTNAME?" --yes-button "No" --no-button "Yes" 10 60) then
-        return 0
-    fi
-
-    sudo su - postgres -c "psql -q -h $PGHOST -p $PGPORT -c \"DROP DATABASE $POSTNAME;\""
-    RET=$?
-    if [ $RET -ne 0 ]; then
-        msgbox "Dropping database $POSTNAME failed. Please check the output and correct any issues."
-        do_exit
+    if (whiptail --title "Are you sure?" --yesno "Completely remove database $POSTNAME?" 10 60) then
+        sudo su - postgres -c "psql -q -h $PGHOST -p $PGPORT -c \"DROP DATABASE $POSTNAME;\""
+        RET=$?
+        if [ $RET -ne 0 ]; then
+            msgbox "Dropping database $POSTNAME failed. Please check the output and correct any issues."
+            return $RET
+        else
+            msgbox "Dropping database $POSTNAME successful"
+        fi
     else
-        msgbox "Dropping database $POSTNAME successful"
+        return 0
     fi
 
 }
@@ -481,6 +488,10 @@ drop_database() {
 rename_database_menu() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     DATABASES=()
 
@@ -517,7 +528,7 @@ rename_database() {
         SOURCE=$(whiptail --backtitle "$( window_title )" --inputbox "Enter name of database to rename" 8 60 "" 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
-            return 0
+            return $RET
         fi
     else
         SOURCE="$1"
@@ -527,37 +538,31 @@ rename_database() {
         DEST=$(whiptail --backtitle "$( window_title )" --inputbox "Enter new name of database" 8 60 "" 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
-            return 0
+            return $RET
         fi
     else
         DEST="$2"
     fi
     log_arg $SOURCE $DEST
 
-    MWCVERSION=$(echo "$MWCCONFIG" | cut -d / -f 5)
-    if [ -n "$MWCVERSION" ]; then
-        log "Stopping node server $MWCVERSION"
-        log_exec sudo service xtuple-$MWCVERSION stop
-    fi
-
-    sudo su - postgres -c "psql -q -h $PGHOST -p $PGPORT -c \"ALTER DATABASE $SOURCE RENAME TO $DEST;\""
+    log_exec sudo su - postgres -c "psql -q -h $PGHOST -p $PGPORT -c \"ALTER DATABASE $SOURCE RENAME TO $DEST;\""
     RET=$?
     if [ $RET -ne 0 ]; then
         msgbox "Renaming database $SOURCE failed. Please check the output and correct any issues."
-        do_exit
+        return $RET
     else
         msgbox "Successfully renamed database $SOURCE to $DEST"
     fi
 
-    if [ -n "$MWCVERSION" ]; then
-        log "Starting node server $MWCVERSION"
-        log_exec sudo service xtuple-$MWCVERSION start
-    fi
 }
 
 inspect_database_menu() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     DATABASES=()
 
@@ -583,6 +588,10 @@ inspect_database_menu() {
 remove_connect_priv() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     log_exec psql -U postgres -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c "REVOKE CONNECT ON DATABASE "$1" FROM public, admin, xtrole;"
 }
@@ -591,6 +600,10 @@ remove_connect_priv() {
 kill_database_connections() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     log_exec psql -U postgres -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='"$1"';"
 }
@@ -599,6 +612,10 @@ kill_database_connections() {
 restore_connect_priv() {
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     log_exec psql -U postgres -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c "GRANT CONNECT ON DATABASE "$1" TO public, admin, xtrole;"
 }
@@ -619,87 +636,92 @@ inspect_database() {
 
 }
 
-set_database_info() {
+set_database_info_select() {
+    CLUSTERS=()
 
-    if (whiptail --title "xTuple Utility v$_REV" --yes-button "Select Cluster" --no-button "Manually Enter"  --yesno "Would you like to choose from installed clusters, or manually enter server information?" 10 60) then
-        CLUSTERS=()
+    while read -r line; do 
+        CLUSTERS+=("$line" "$line")
+    done < <( sudo pg_lsclusters | tail -n +2 )
 
-        while read -r line; do 
-            CLUSTERS+=("$line" "$line")
-        done < <( sudo pg_lsclusters | tail -n +2 )
+     if [ -z "$CLUSTERS" ]; then
+        msgbox "No database clusters detected on this system"
+        return 1
+    fi
 
-         if [ -z "$CLUSTERS" ]; then
-            msgbox "No database clusters detected on this system"
-            return 1
-        fi
+    CLUSTER=$(whiptail --title "xTuple Utility v$_REV" --menu "Select cluster to use" 16 120 5 "${CLUSTERS[@]}" --notags 3>&1 1>&2 2>&3)
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
-        CLUSTER=$(whiptail --title "xTuple Utility v$_REV" --menu "Select cluster to use" 16 120 5 "${CLUSTERS[@]}" --notags 3>&1 1>&2 2>&3)
+    if [ -z "$CLUSTER" ]; then
+        msgbox "No database clusters detected on this system"
+        return 1
+    fi
+
+    export PGVER=`awk  '{print $1}' <<< "$CLUSTER"`
+    export PGNAME=`awk  '{print $2}' <<< "$CLUSTER"`
+    export PGPORT=`awk  '{print $3}' <<< "$CLUSTER"`
+    export PGHOST=localhost
+    export PGUSER=postgres
+
+    PGPASSWORD=$(whiptail --backtitle "$( window_title )" --passwordbox "Enter postgres user password" 8 60 3>&1 1>&2 2>&3)
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    else
+        export PGPASSWORD
+    fi
+
+    if [ -z "$PGVER" ] || [ -z "$PGNAME" ] || [ -z "$PGPORT" ]; then
+        msgbox "Could not determine database version or name"
+        return 0
+    fi
+}
+
+set_database_info_manual() {
+
+    if [ -z $PGHOST ]; then
+        PGHOST=$(whiptail --backtitle "$( window_title )" --inputbox "Hostname" 8 60 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
+            unset PGHOST && unset PGPORT && unset PGUSER && unset PGPASSWORD
             return $RET
+        else
+            export PGHOST
         fi
-
-        if [ -z "$CLUSTER" ]; then
-            msgbox "No database clusters detected on this system"
-            return 1
-        fi
-
-        export PGVER=`awk  '{print $1}' <<< "$CLUSTER"`
-        export PGNAME=`awk  '{print $2}' <<< "$CLUSTER"`
-        export PGPORT=`awk  '{print $3}' <<< "$CLUSTER"`
-        export PGHOST=localhost
-        export PGUSER=postgres
-
-        PGPASSWORD=$(whiptail --backtitle "$( window_title )" --passwordbox "Enter postgres user password" 8 60 3>&1 1>&2 2>&3)
+    fi
+    if [ -z $PGPORT ] ; then
+        PGPORT=$(whiptail --backtitle "$( window_title )" --inputbox "Port" 8 60 3>&1 1>&2 2>&3)
         RET=$?
         if [ $RET -ne 0 ]; then
+            unset PGHOST && unset PGPORT && unset PGUSER && unset PGPASSWORD
+            return $RET
+        else
+            export PGPORT
+        fi
+    fi
+    if [ -z $PGUSER ] ; then
+        PGUSER=$(whiptail --backtitle "$( window_title )" --inputbox "Username" 8 60 3>&1 1>&2 2>&3)
+        RET=$?
+        if [ $RET -ne 0 ]; then
+            unset PGHOST && unset PGPORT && unset PGUSER && unset PGPASSWORD
+            return $RET
+        else
+            export PGUSER
+        fi
+    fi
+    if [ -z $PGPASSWORD ] ; then
+        PGPASSWORD=$(whiptail --backtitle "$( window_title )" --passwordbox "Password" 8 60 3>&1 1>&2 2>&3)
+        RET=$?
+        if [ $RET -ne 0 ]; then
+            unset PGHOST && unset PGPORT && unset PGUSER && unset PGPASSWORD
             return $RET
         else
             export PGPASSWORD
         fi
-
-        if [ -z "$PGVER" ] || [ -z "$PGNAME" ] || [ -z "$PGPORT" ]; then
-            msgbox "Could not determine database version or name"
-            return 0
-        fi
-    else
-        if [ -z $PGHOST ]; then
-            PGHOST=$(whiptail --backtitle "$( window_title )" --inputbox "Hostname" 8 60 3>&1 1>&2 2>&3)
-            RET=$?
-            if [ $RET -ne 0 ]; then
-                return $RET
-            else
-                export PGHOST
-            fi
-        fi
-        if [ -z $PGPORT ] ; then
-            PGPORT=$(whiptail --backtitle "$( window_title )" --inputbox "Port" 8 60 3>&1 1>&2 2>&3)
-            RET=$?
-            if [ $RET -ne 0 ]; then
-                return $RET
-            else
-                export PGPORT
-            fi
-        fi
-        if [ -z $PGUSER ] ; then
-            PGUSER=$(whiptail --backtitle "$( window_title )" --inputbox "Username" 8 60 3>&1 1>&2 2>&3)
-            RET=$?
-            if [ $RET -ne 0 ]; then
-                return $RET
-            else
-                export PGUSER
-            fi
-        fi
-        if [ -z $PGPASSWORD ] ; then
-            PGPASSWORD=$(whiptail --backtitle "$( window_title )" --passwordbox "Password" 8 60 3>&1 1>&2 2>&3)
-            RET=$?
-            if [ $RET -ne 0 ]; then
-                return $RET
-            else
-                export PGPASSWORD
-            fi
-        fi
     fi
+
 }
 
 clear_database_info() {
@@ -711,11 +733,18 @@ clear_database_info() {
 
 check_database_info() {
     if [ -z $PGHOST ] || [ -z $PGPORT ] || [ -z $PGUSER ] || [ -z $PGPASSWORD ]; then
-        set_database_info
-        RET=$?
-        if [ $RET -eq 255 ]; then
-            return 0
+        if (whiptail --title "xTuple Utility v$_REV" --yes-button "Select Cluster" --no-button "Manually Enter"  --yesno "Would you like to choose from installed clusters, or manually enter server information?" 10 60) then
+            set_database_info_select
+            RET=$?
+            return $RET
         else
+            # I specifically need to check for ESC here as I am using the yesno box as a multiple choice question, 
+            # so it choses no code even during escape which in this case I want to actually escape when someone hits escape. 
+            if [ $? -eq 255 ]; then
+                return 255
+            fi
+            set_database_info_manual
+            RET=$?
             return $RET
         fi
     else
@@ -730,6 +759,9 @@ check_database_info() {
 # $1 is database
 # $2 is version to upgrade to
 upgrade_database() {
+
+    msgbox "This functionality is forthcoming..."
+    return 0 # for now
     DATABASE=demo481
     APP=`sudo su - postgres -c "psql -At -U ${PGUSER} -p ${PGPORT} $DATABASE -c \"SELECT fetchmetrictext('Application') AS application;\""`
     log "Detected application $APP"
@@ -737,8 +769,6 @@ upgrade_database() {
     log "Detected server version $VER"
     UPS=`curl -s http://api.xtuple.org/upgradepath.php\?package=$APP\&fromver=3.7.0\&tover=4.8.1`
     log "Detected upgrades $UPS"
-    
-    return 0; # for now
 
     if [ -z "$1" ]; then
         DATABASES=()

--- a/database.sh
+++ b/database.sh
@@ -733,13 +733,13 @@ clear_database_info() {
 
 check_database_info() {
     if [ -z $PGHOST ] || [ -z $PGPORT ] || [ -z $PGUSER ] || [ -z $PGPASSWORD ]; then
-        if (whiptail --title "xTuple Utility v$_REV" --yes-button "Select Cluster" --no-button "Manually Enter"  --yesno "Would you like to choose from installed clusters, or manually enter server information?" 10 60) then
+        if (whiptail --yes-button "Select Cluster" --no-button "Manually Enter"  --yesno "Would you like to choose from installed clusters, or manually enter server information?" 10 60) then
             set_database_info_select
             RET=$?
             return $RET
         else
             # I specifically need to check for ESC here as I am using the yesno box as a multiple choice question, 
-            # so it choses no code even during escape which in this case I want to actually escape when someone hits escape. 
+            # so it chooses no code even during escape which in this case I want to actually escape when someone hits escape. 
             if [ $? -eq 255 ]; then
                 return 255
             fi

--- a/mainmenu.sh
+++ b/mainmenu.sh
@@ -5,21 +5,21 @@ extras_menu() {
 
     while true; do
 
-        CC=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Extras\ Menu )" 0 0 1 --cancel-button "Exit" --ok-button "Select" \
+        CC=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Extras\ Menu )" 0 0 1 --cancel-button "Cancel" --ok-button "Select" \
             "1" "Install Prerequisites" \
             "2" "Return to main menu" \
             3>&1 1>&2 2>&3)
         
         RET=$?
         
-        if [ $RET -eq 1 ]; then
-            do_exit
-        elif [ $RET -eq 0 ]; then
+        if [ $RET -ne 0 ]; then
+            break
+        else
             case "$CC" in
             "1") install_prereqs ;;
             "2") break ;;
-            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu" && do_exit ;;
-            esac || msgbox "I don't know how you got here!!! >> $CC <<  Report on GitHub"
+            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu $CC" && break ;;
+            esac
         fi
     done
 }
@@ -42,9 +42,9 @@ main_menu() {
         
         RET=$?
         
-        if [ $RET -eq 1 ]; then
+        if [ $RET -ne 0 ]; then
             do_exit
-        elif [ $RET -eq 0 ]; then
+        else
             case "$CC" in
             "1") provision_menu ;;
             "2") postgresql_menu ;;
@@ -54,7 +54,7 @@ main_menu() {
             "6") openrpt_menu ;;
             "7") extras_menu ;;
             *) msgbox "Don't know how you got here! Please report on GitHub >> mainmenu" && do_exit ;;
-            esac || msgbox "I don't know how you got here!!! >> $CC <<  Report on GitHub"
+            esac
         fi
     done
 }

--- a/mobileclient.sh
+++ b/mobileclient.sh
@@ -7,7 +7,7 @@ mwc_menu() {
     log "Opened Web Client menu"
 
     while true; do
-        PGM=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Web\ Client\ Menu )" 0 0 9 --cancel-button "Exit" --ok-button "Select" \
+        PGM=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Web\ Client\ Menu )" 0 0 9 --cancel-button "Cancel" --ok-button "Select" \
             "1" "Install xTuple Web Client" \
             "2" "Remove xTuple Web Client" \
             "3" "Return to main menu" \

--- a/mobileclient.sh
+++ b/mobileclient.sh
@@ -15,15 +15,15 @@ mwc_menu() {
 
         RET=$?
 
-        if [ $RET -eq 1 ]; then
-            do_exit
-        elif [ $RET -eq 0 ]; then
+        if [ $RET -ne 0 ]; then
+            break
+        else
             case "$PGM" in
             "1") install_mwc_menu ;;
             "2") log_choice remove_mwc ;;
             "3") break ;;
-            *) msgbox "Error. How did you get here? >> mwc_menu / $PGM" && do_exit ;;
-            esac || postgresql_menu
+            *) msgbox "Error. How did you get here? >> mwc_menu / $PGM" && break ;;
+            esac
         fi
     done
 
@@ -36,11 +36,11 @@ install_mwc_menu() {
 
     MENUVER=$(whiptail --backtitle "$( window_title )" --menu "Choose Web Client Version" 15 60 7 --cancel-button "Exit" --ok-button "Select" \
         $(paste -d '\n' \
-	   <(seq 0 9) \
-	   <(echo $TAGVERSIONS | tr ' ' '\n')) \
-	   $(paste -d '\n' \
-	   <(seq 10 14) \
-	   <(echo $HEADVERSIONS | tr ' ' '\n')) \
+        <(seq 0 9) \
+        <(echo $TAGVERSIONS | tr ' ' '\n')) \
+        $(paste -d '\n' \
+        <(seq 10 14) \
+        <(echo $HEADVERSIONS | tr ' ' '\n')) \
         "15" "Return to main menu" \
         3>&1 1>&2 2>&3)
 
@@ -48,16 +48,16 @@ install_mwc_menu() {
 
     if [ $RET -eq 0 ]; then
         if [ $MENUVER -eq 16 ]; then
-	       return 0;
-	   elif [ $MENUVER -lt 10 ]; then
-	       read -a tagversionarray <<< $TAGVERSIONS
-	       MWCVERSION=${tagversionarray[$MENUVER]}
-               MWCSTRING=v$MWCVERSION
-	   else
-	       read -a headversionarray <<< $HEADVERSIONS
-	       MWCVERSION=${headversionarray[(($MENUVER-10))]}
-               MWCSTRING=$MWCVERSION
-	   fi
+            return 0;
+        elif [ $MENUVER -lt 10 ]; then
+            read -a tagversionarray <<< $TAGVERSIONS
+            MWCVERSION=${tagversionarray[$MENUVER]}
+            MWCSTRING=v$MWCVERSION
+        else
+            read -a headversionarray <<< $HEADVERSIONS
+            MWCVERSION=${headversionarray[(($MENUVER-10))]}
+            MWCSTRING=$MWCVERSION
+        fi
     else
         return $RET
     fi
@@ -73,6 +73,10 @@ install_mwc_menu() {
     log "Chose mobile name $MWCNAME"
 
     check_database_info
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        return $RET
+    fi
 
     DATABASES=()
 
@@ -81,14 +85,14 @@ install_mwc_menu() {
      done < <( sudo su - postgres -c "psql -h $PGHOST -p $PGPORT --tuples-only -P format=unaligned -c \"SELECT datname FROM pg_database WHERE datname NOT IN ('postgres', 'template0', 'template1');\"" )
      if [ -z "$DATABASES" ]; then
         msgbox "No databases detected on this system"
-        return 0
+        return 1
     fi
 
     DATABASE=$(whiptail --title "PostgreSQL Databases" --menu "List of databases on this cluster" 16 60 5 "${DATABASES[@]}" --notags 3>&1 1>&2 2>&3)
     RET=$?
     if [ $RET -ne 0 ]; then
         log "There was an error selecting the database.. exiting"
-        do_exit
+        return $RET
     fi
 
     log "Chose database $DATABASE"
@@ -107,7 +111,6 @@ install_mwc_menu() {
         if [ $RET -ne 0 ]; then
             return $RET
         fi
-
     else
         log "Not installing the commercial extensions"
         PRIVATEEXT=false
@@ -144,7 +147,7 @@ install_mwc() {
 
     log "Creating xtuple user..."
     log_exec sudo useradd xtuple -m -s /bin/bash
-    
+
     log "Installing n..."
     cd $WORKDIR    
     wget https://raw.githubusercontent.com/visionmedia/n/master/bin/n -qO n

--- a/mobileclient.sh
+++ b/mobileclient.sh
@@ -258,3 +258,7 @@ install_mwc() {
     log "All set! You should now be able to log on to this server at https://$IP:8443 with username admin and password admin. Make sure you change your password!"
 
 }
+
+remove_mwc() {
+    msgbox "Uninstalling the mobile client is not yet supported"
+}

--- a/nginx.sh
+++ b/nginx.sh
@@ -40,7 +40,7 @@ nginx_prompt() {
             export NGINXHOSTNAME
         fi
     fi
-    
+
     if [ -z $DOMAIN ]; then
         DOMAIN=$(whiptail --backtitle "$( window_title )" --inputbox "Domain name" 8 60 3>&1 1>&2 2>&3)
         RET=$?
@@ -51,7 +51,7 @@ nginx_prompt() {
             export DOMAIN
         fi
     fi
-    
+
     log_choice install_nginx $NGINXHOSTNAME $DOMAIN
 }
 
@@ -61,8 +61,8 @@ install_nginx() {
 
     log "Installing nginx"
 
-    export NGINXHOSTNAME=$1
-    export DOMAIN=$2
+    NGINXHOSTNAME=$1
+    DOMAIN=$2
 
     log_arg $NGINXHOSTNAME $DOMAIN
 
@@ -101,6 +101,9 @@ install_nginx() {
     else
         msgbox "nginx installed and configured successfully."
     fi
+
+    unset NGINXHOSTNAME
+    unset DOMAIN
 }
 
 remove_nginx() {

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -70,7 +70,7 @@ install_xvfb() {
     log_exec sudo apt-get -y install xvfb
     RET=$?
     if [ $RET -ne 0 ]; then
-        msgbox "There was an error installing OpenRPT. Check the log and correct any issues before trying again"
+        msgbox "There was an error installing xvfb. Check the log and correct any issues before trying again"
     fi
     return $RET
 

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -24,7 +24,7 @@ openrpt_menu() {
             "3") log_choice install_xvfb ;;
             "4") log_choice remove_xvfb ;;
             "5") break ;;
-            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu $CC" && break ;;
+            *) msgbox "Don't know how you got here! Please report on GitHub >> openrpt_menu $CC" && break ;;
             esac
         fi
     done

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -24,7 +24,7 @@ openrpt_menu() {
             "3") log_choice install_xvfb ;;
             "4") log_choice remove_xvfb ;;
             "5") break ;;
-            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu $CC" && do_exit ;;
+            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu $CC" && break ;;
             esac
         fi
     done

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -5,7 +5,7 @@ openrpt_menu() {
 
     while true; do
 
-        CC=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Extras\ Menu )" 0 0 1 --cancel-button "Exit" --ok-button "Select" \
+        CC=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title Extras\ Menu )" 0 0 1 --cancel-button "Cancel" --ok-button "Select" \
             "1" "Install Package" \
             "2" "Build from source" \
             "3" "Install xvfb" \
@@ -15,17 +15,17 @@ openrpt_menu() {
         
         RET=$?
         
-        if [ $RET -eq 1 ]; then
-            do_exit
-        elif [ $RET -eq 0 ]; then
+        if [ $RET -ne 0 ]; then
+            break
+        else
             case "$CC" in
             "1") log_choice install_openrpt ;;
             "2") log_choice build_openrpt ;;
             "3") log_choice install_xvfb ;;
             "4") log_choice remove_xvfb ;;
             "5") break ;;
-            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu" && do_exit ;;
-            esac || msgbox "I don't know how you got here!!! >> $CC <<  Report on GitHub"
+            *) msgbox "Don't know how you got here! Please report on GitHub >> extras_menu $CC" && do_exit ;;
+            esac
         fi
     done
 }
@@ -37,7 +37,7 @@ install_openrpt() {
     log_exec sudo apt-get -y -qq install openrpt
     RET=$?
     if [ $RET -ne 0 ]; then
-      do_exit
+        msgbox "There was an error installing OpenRPT. Check the log and correct any issues before trying again"
     fi
     return $RET
 
@@ -45,7 +45,6 @@ install_openrpt() {
 
 build_openrpt() {
 
-    log_arg
     cd $WORKDIR || die "Couldn't cd $WORKDIR"
 
     log "preparing to build OpenRPT from source"
@@ -67,12 +66,11 @@ build_openrpt() {
 
 install_xvfb() {
 
-    log_arg
     log "Installing xvfb..."
     log_exec sudo apt-get -y install xvfb
     RET=$?
     if [ $RET -ne 0 ]; then
-      do_exit
+        msgbox "There was an error installing OpenRPT. Check the log and correct any issues before trying again"
     fi
     return $RET
 
@@ -80,15 +78,13 @@ install_xvfb() {
 
 remove_xvfb() {
 
-    log_arg
-    if (whiptail --title "Are you sure?" --yesno "Uninstall xvfb?" --yes-button "No" --no-button "Yes" 10 60) then
-      return 0
+    if (whiptail --title "Are you sure?" --yesno "Uninstall xvfb?" --yes-button "Yes" --no-button "No" 10 60) then
+        log "Uninstalling xvfb..."
+        log_exec sudo apt-get -y remove xvfb
+        RET=$?
+        return $RET
     else
-      log "Uninstalling xvfb..."
+        return 0
     fi
-
-    log_exec sudo apt-get -y remove xvfb
-    RET=$?
-    return $RET
 
 }

--- a/provision.sh
+++ b/provision.sh
@@ -3,7 +3,7 @@ provision_menu() {
 
     log "Opened provisioning menu"
 
-    ACTIONS=$(whiptail --separate-output --title "Select Components" --checklist --cancel-button "Return" \
+    ACTIONS=$(whiptail --separate-output --title "Select Components" --checklist --cancel-button "Cancel" \
     "Please choose the actions you would like to take" 15 60 7 \
     "installpg93" "Install PostgreSQL 9.3" ON \
     "provisioncluster" "Provision PostgreSQL Cluster" ON \
@@ -16,15 +16,14 @@ provision_menu() {
 
     RET=$?
     if [ $RET = 0 ]; then
-    if [[ $ACTIONS == *"installpg93"* ]] && [[ $ACTIONS != *"provisioncluster"* ]]
-    then
-        msgbox "You are about to install PostgreSQL but not provision to any clusters. \nYou will need to create a cluster manually before you can initialize \nit for xTuple. If you have chosen to initialize the database or install a demo \nthose actions will be skipped."
-        SKIP=1
-        ACTIONS=`sed "/initdb/d" <<< "$ACTIONS"`
-        log "Skipping initdb because provisioncluster was not chosen."
-        ACTIONS=`sed "/demodb/d" <<< "$ACTIONS"`
-        log "Skipping demodb because provisioncluster was not chosen."
-    fi
+        if [[ $ACTIONS == *"installpg93"* ]] && [[ $ACTIONS != *"provisioncluster"* ]]; then
+            msgbox "You are about to install PostgreSQL but not provision to any clusters. \nYou will need to create a cluster manually before you can initialize \nit for xTuple. If you have chosen to initialize the database or install a demo \nthose actions will be skipped."
+            SKIP=1
+            ACTIONS=`sed "/initdb/d" <<< "$ACTIONS"`
+            log "Skipping initdb because provisioncluster was not chosen."
+            ACTIONS=`sed "/demodb/d" <<< "$ACTIONS"`
+            log "Skipping demodb because provisioncluster was not chosen."
+        fi
         for i in $ACTIONS; do   
             case "$i" in
             "installpg93") log_choice install_postgresql 9.3
@@ -43,12 +42,14 @@ provision_menu() {
             "webclient") log_choice install_mwc_menu
                       ;;
              *) ;;
-         esac || main_menu
+            esac || main_menu
         done
     fi
     
     if [ -n "$ACTIONS" ]; then
         msgbox "The following actions were completed: \n$ACTIONS" 
+    elif [ -z "$ACTIONS" ]; then
+        msgbox "No actions were taken."
     fi
     return 0;
 }

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -7,7 +7,7 @@ export WORKDIR=`pwd`
 
 #set some defaults
 PGVERSION=9.3
-XTVERSION=4.8.1
+XTVERSION=4.9.1
 _XTVERSION=${XTVERSION//./}
 INSTANCE=xtuple
 DBTYPE=demo


### PR DESCRIPTION
Uses a consistent flow now, where bottom options are select or cancel everywhere except the main menu where cancelling/escaping exits the utility completely. The escape key can be considered a "Back" button, where at any point it should take you back to the menu that lead you where you are, even if you are two or three text boxes into input, escaping will back out to the menu. 

Updates the default version to 4.9.1, replaced the 4.9.0 demo database entries with 4.9.1, using log_exec in more places, removes question to add database to the mobile client since it was showing up in the wrong places. 

Fixes #54 and #56. Closes #37 without fixing.