### PR TITLE
Apply the correct postgres version everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Help Output:
 To get an interactive menu run xtuple-utility.sh with no arguments
 
   -h    Show this message
-  -a    Install all (PostgreSQL (currently 9.3), demo database (currently 4.9.1) and web client (currently 4.9.1))
+  -a    Install all (PostgreSQL (currently 9.4), demo database (currently 4.9.1) and web client (currently 4.9.1))
   -d    Specify database name to create
   -p    Override PostgreSQL version
   -n    Override instance name

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Help Output:
 To get an interactive menu run xtuple-utility.sh with no arguments
 
   -h    Show this message
-  -a    Install all (PostgreSQL (currently 9.4), demo database (currently 4.9.1) and web client (currently 4.9.1))
+  -a    Install all (PostgreSQL (currently 9.3), demo database (currently 4.9.1) and web client (currently 4.9.1))
   -d    Specify database name to create
   -p    Override PostgreSQL version
   -n    Override instance name

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone https://github.com/xtuple/xtuple-admin-utility.git
 
 cd xtuple-admin-utility && ./xtuple-utility.sh
 
-If you are installing from scratch, choose privisioning from the main menu. To install everything, choose installpg, provisioncluster, initdb, demodb, and webclient. You will be prompted along the way for information such as postgresql port, cluster name, postgres user password, admin passwords and so on. Remember what you choose! Work on implementing #7 will be forthcoming. 
+If you are installing from scratch, choose provisioning from the main menu. To install everything, choose installpg, provisioncluster, initdb, demodb, and webclient. You will be prompted along the way for information such as postgresql port, cluster name, postgres user password, admin passwords and so on. Remember what you choose! Work on implementing #7 will be forthcoming. 
 
 For an unattended install on a clean machine, try: ./xtuple-utility.sh -a
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone https://github.com/xtuple/xtuple-admin-utility.git
 
 cd xtuple-admin-utility && ./xtuple-utility.sh
 
-If you are installing from scratch, choose privisioning from the main menu. To install everything, choose installpg93, provisioncluster, initdb, demodb, and webclient. You will be prompted along the way for information such as postgresql port, cluster name, postgres user password, admin passwords and so on. Remember what you choose! Work on implementing #7 will be forthcoming. 
+If you are installing from scratch, choose privisioning from the main menu. To install everything, choose installpg, provisioncluster, initdb, demodb, and webclient. You will be prompted along the way for information such as postgresql port, cluster name, postgres user password, admin passwords and so on. Remember what you choose! Work on implementing #7 will be forthcoming. 
 
 For an unattended install on a clean machine, try: ./xtuple-utility.sh -a
 

--- a/common.sh
+++ b/common.sh
@@ -108,7 +108,7 @@ install_prereqs() {
                     sudo add-apt-repository -y "deb http://ftp.debian.org/debian $(lsb_release -cs)-backports main"
                     sudo apt-get update
                 fi
-                sudo apt-get -y install axel git whiptail unzip bzip2 wget curl build-essential libssl-dev postgresql-client-9.3
+                sudo apt-get -y install axel git whiptail unzip bzip2 wget curl build-essential libssl-dev postgresql-client-$PGVERSION
                 RET=$?
                 if [ $RET -ne 0 ]; then
                     msgbox "Something went wrong installing prerequisites for $DISTRO/$CODENAME. Check the log for more info. "

--- a/postgresql.sh
+++ b/postgresql.sh
@@ -6,9 +6,9 @@ postgresql_menu() {
 
     while true; do
         PGM=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title PostgreSQL\ Menu )" 0 0 9 --cancel-button "Cancel" --ok-button "Select" \
-            "1" "Install PostgreSQL 9.3" \
-            "2" "Remove PostgreSQL 9.3" \
-            "3" "Purge PostgreSQL 9.3" \
+            "1" "Install PostgreSQL $PGVERSION" \
+            "2" "Remove PostgreSQL $PGVERSION" \
+            "3" "Purge PostgreSQL $PGVERSION" \
             "4" "List provisioned clusters" \
             "5" "Provision database cluster" \
             "6" "Drop database cluster" \
@@ -25,9 +25,9 @@ postgresql_menu() {
             break
         elif [ $RET -eq 0 ]; then
             case "$PGM" in
-            "1") log_choice install_postgresql 9.3 ;;
-            "2") log_choice remove_postgresql 9.3 ;;
-            "3") log_choice purge_postgresql 9.3 ;;
+            "1") log_choice install_postgresql $PGVERSION ;;
+            "2") log_choice remove_postgresql $PGVERSION ;;
+            "3") log_choice purge_postgresql $PGVERSION ;;
             "4") log_choice list_clusters ;;
             "5") log_choice provision_cluster ;;
             "6") drop_cluster_menu ;;

--- a/provision.sh
+++ b/provision.sh
@@ -5,7 +5,7 @@ provision_menu() {
 
     ACTIONS=$(whiptail --separate-output --title "Select Components" --checklist --cancel-button "Cancel" \
     "Please choose the actions you would like to take" 15 60 7 \
-    "installpg93" "Install PostgreSQL 9.3" ON \
+    "installpg" "Install PostgreSQL $PGVERSION" ON \
     "provisioncluster" "Provision PostgreSQL Cluster" ON \
     "initdb" "Add xTuple admin user and role" ON \
     "demodb" "Load xTuple Database" OFF \
@@ -16,7 +16,7 @@ provision_menu() {
 
     RET=$?
     if [ $RET = 0 ]; then
-        if [[ $ACTIONS == *"installpg93"* ]] && [[ $ACTIONS != *"provisioncluster"* ]]; then
+        if [[ $ACTIONS == *"installpg"* ]] && [[ $ACTIONS != *"provisioncluster"* ]]; then
             msgbox "You are about to install PostgreSQL but not provision to any clusters. \nYou will need to create a cluster manually before you can initialize \nit for xTuple. If you have chosen to initialize the database or install a demo \nthose actions will be skipped."
             SKIP=1
             ACTIONS=`sed "/initdb/d" <<< "$ACTIONS"`
@@ -26,10 +26,10 @@ provision_menu() {
         fi
         for i in $ACTIONS; do   
             case "$i" in
-            "installpg93") log_choice install_postgresql 9.3
-                           log_choice drop_cluster 9.3 main auto
+            "installpg") log_choice install_postgresql $PGVERSION
+                           log_choice drop_cluster $PGVERSION main auto
                            ;;
-            "provisioncluster") log_choice provision_cluster 9.3
+            "provisioncluster") log_choice provision_cluster $PGVERSION
                                 ;;
             "initdb") log_choice prepare_database auto
                       ;;

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -6,7 +6,7 @@ export _REV="0.2Alpha"
 export WORKDIR=`pwd`
 
 #set some defaults
-export PGVERSION=9.4
+export PGVERSION=9.3
 export XTVERSION=4.9.2
 _XTVERSION=${XTVERSION//./}
 export INSTANCE=xtuple

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -6,7 +6,7 @@ export _REV="0.2Alpha"
 export WORKDIR=`pwd`
 
 #set some defaults
-export PGVERSION=9.3
+export PGVERSION=9.4
 export XTVERSION=4.9.2
 _XTVERSION=${XTVERSION//./}
 export INSTANCE=xtuple
@@ -98,7 +98,7 @@ case "$_DISTRO" in
         case "$_CODENAME" in
             "trusty") ;;
             "utopic") ;;
-            "vivid") export PGVERSION=9.4 ;; # 9.3 is marked obsolete on 15.04...
+            "vivid") ;;
             *) log "We currently only support Ubuntu 14.04 LTS,14.10 and 15.04. Current release: `lsb_release -r -s`" 
                do_exit
                ;;


### PR DESCRIPTION
Since 9.3 is marked obsolete on 15.04, we use 9.4.
This makes sure whichever version is selected, it's used everywhere.