### PR TITLE
Check out the correct branch of MWC if running xTAU without menus.

### DIFF
--- a/mobileclient.sh
+++ b/mobileclient.sh
@@ -50,11 +50,11 @@ install_mwc_menu() {
         elif [ $MENUVER -lt 10 ]; then
             read -a tagversionarray <<< $TAGVERSIONS
             MWCVERSION=${tagversionarray[$MENUVER]}
-            MWCSTRING=v$MWCVERSION
+            MWCREFSPEC=v$MWCVERSION
         else
             read -a headversionarray <<< $HEADVERSIONS
             MWCVERSION=${headversionarray[(($MENUVER-10))]}
-            MWCSTRING=$MWCVERSION
+            MWCREFSPEC=$MWCVERSION
         fi
     else
         return $RET
@@ -114,33 +114,40 @@ install_mwc_menu() {
         PRIVATEEXT=false
     fi
 
-    log_choice install_mwc $MWCVERSION $MWCNAME $PRIVATEEXT $DATABASE $GITHUBNAME $GITHUBPASS
+    log_choice install_mwc $MWCVERSION $MWCREFSPEC $MWCNAME $PRIVATEEXT $DATABASE $GITHUBNAME $GITHUBPASS
 }
 
 
 # $1 is xtuple version
-# $2 is the instance name
-# $3 is to install private extensions
-# $4 is database name
+# $2 is the git refspec
+# $3 is the instance name
+# $4 is to install private extensions
+# $5 is database name
+# $6 is github username
+# $7 is github password
 install_mwc() {
 
     log "installing web client"
 
     export MWCVERSION=$1
-    export MWCNAME="$2"
+    export MWCREFSPEC=$2
+    export MWCNAME="$3"
 
-    if [ -z "$3" ] || [ ! "$3" = "true" ]; then
+    if [ -z "$4" ] || [ ! "$4" = "true" ]; then
         PRIVATEEXT=false
     else
         PRIVATEEXT=true
     fi
     
-    if [ -z "$4" ] && [ -z "$PGDATABASE" ]; then
+    if [ -z "$5" ] && [ -z "$PGDATABASE" ]; then
         log "No database name passed to install_mwc... exiting."
         do_exit
     else
-        PGDATABASE=$4
+        PGDATABASE=$5
     fi
+
+    export GITHUBNAME=$6
+    export GITHUBPASS=$7
     log_arg $MWCVERSION $MWCNAME $PRIVATEEXT $PGDATABASE
 
     log "Creating xtuple user..."
@@ -167,11 +174,11 @@ install_mwc() {
     log_exec sudo chown -R xtuple.xtuple /opt/xtuple
 
     # main code
-    log_exec sudo su - xtuple -c "cd /opt/xtuple/$MWCVERSION/"$MWCNAME" && git clone https://github.com/xtuple/xtuple.git && cd  /opt/xtuple/$MWCVERSION/"$MWCNAME"/xtuple && git checkout $MWCSTRING && git submodule update --init --recursive && npm install bower && npm install"
+    log_exec sudo su - xtuple -c "cd /opt/xtuple/$MWCVERSION/"$MWCNAME" && git clone https://github.com/xtuple/xtuple.git && cd  /opt/xtuple/$MWCVERSION/"$MWCNAME"/xtuple && git checkout $MWCREFSPEC && git submodule update --init --recursive && npm install bower && npm install"
     # private extensions
     if [ $PRIVATEEXT = "true" ]; then
         log "Installing the commercial extensions"
-        log_exec sudo su xtuple -c "cd /opt/xtuple/$MWCVERSION/"$MWCNAME" && git clone https://"$5":"$6"@github.com/xtuple/private-extensions.git && cd /opt/xtuple/$MWCVERSION/"$MWCNAME"/private-extensions && git checkout $MWCSTRING && git submodule update --init --recursive && npm install"
+        log_exec sudo su xtuple -c "cd /opt/xtuple/$MWCVERSION/"$MWCNAME" && git clone https://"$GITHUBNAME":"$GITHUBPASS"@github.com/xtuple/private-extensions.git && cd /opt/xtuple/$MWCVERSION/"$MWCNAME"/private-extensions && git checkout $MWCREFSPEC && git submodule update --init --recursive && npm install"
     else
         log "Not installing the commercial extensions"
     fi

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -6,11 +6,13 @@ openrpt_menu() {
     while true; do
 
         CC=$(whiptail --backtitle "$( window_title )" --menu "$( menu_title OpenRPT\ Menu )" 0 0 1 --cancel-button "Cancel" --ok-button "Select" \
-            "1" "Install Package" \
-            "2" "Build from source" \
-            "3" "Install xvfb" \
-            "4" "Remove xvfb" \
-            "5" "Return to main menu" \
+            "1" "Install All" \
+            "2" "Install Package" \
+            "3" "Build from source" \
+            "4" "Install xvfb" \
+            "5" "Remove xvfb" \
+            "6" "Install initscript" \
+            "7" "Return to main menu" \
             3>&1 1>&2 2>&3)
         
         RET=$?
@@ -19,11 +21,13 @@ openrpt_menu() {
             break
         else
             case "$CC" in
-            "1") log_choice install_openrpt ;;
-            "2") log_choice build_openrpt ;;
-            "3") log_choice install_xvfb ;;
-            "4") log_choice remove_xvfb ;;
-            "5") break ;;
+            "1") log_choice setup_webprint ;;
+            "2") log_choice install_openrpt ;;
+            "3") log_choice build_openrpt ;;
+            "4") log_choice install_xvfb ;;
+            "5") log_choice remove_xvfb ;;
+            "6") log_choice install_xtuple_xvfb;;
+            "7") break ;;
             *) msgbox "Don't know how you got here! Please report on GitHub >> openrpt_menu $CC" && break ;;
             esac
         fi

--- a/openrpt.sh
+++ b/openrpt.sh
@@ -88,3 +88,17 @@ remove_xvfb() {
     fi
 
 }
+
+install_xtuple_xvfb() {
+    log "Installing xtuple-Xvfb to /etc/init.d..."
+    log_exec sudo cp $WORKDIR/templates/xtuple-Xvfb /etc/init.d 
+    log_exec sudo chmod 755 /etc/init.d/xtuple-Xvfb 
+    log_exec sudo update-rc.d xtuple-Xvfb defaults
+    log_exec sudo service xtuple-Xvfb start
+}
+
+setup_webprint() {
+    install_openrpt
+    install_xvfb
+    install_xtuple_xvfb
+}

--- a/templates/xtuple-Xvfb
+++ b/templates/xtuple-Xvfb
@@ -1,0 +1,138 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          Xvfb
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: run Xvfb for use by OpenRPT
+# Description:       Control the Xvfb X11 server so xTuple's OpenRPT can
+#                    render reports when called by the xTuple ERP web client.
+### END INIT INFO
+
+# Author: Gil Moskowitz <gmoskowitz@xtuple.com>
+
+# Do NOT "set -e"
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="Xvfb for use by OpenRPT"
+NAME=Xvfb
+DAEMON=/usr/bin/$NAME
+DAEMON_ARGS=":17"
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
+
+do_start()
+{
+  # Return
+  #   0 if daemon has been started
+  #   1 if daemon was already running
+  #   2 if daemon could not be started
+  start-stop-daemon --start --pidfile $PIDFILE --quiet --test \
+                    --exec $DAEMON > /dev/null  || return 1
+  start-stop-daemon --start --pidfile $PIDFILE --make-pidfile --background \
+                    --exec $DAEMON $DAEMON_ARGS || return 2
+}
+
+do_stop()
+{
+  # Return
+  #   0 if daemon has been stopped
+  #   1 if daemon was already stopped
+  #   2 if daemon could not be stopped
+  #   other if a failure occurred
+  start-stop-daemon --stop --pidfile $PIDFILE --quiet --name $NAME \
+                    --retry=TERM/30/KILL/5
+  RETVAL="$?"
+  [ "$RETVAL" = 2 ] && return 2
+  # Wait for children to finish too if this is a daemon that forks
+  # and if the daemon is only ever run from this initscript.
+  # If the above conditions are not satisfied then add some other code
+  # that waits for the process to drop all resources that could be
+  # needed by services started subsequently.  A last resort is to
+  # sleep for some time.
+  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+  [ "$?" = 2 ] && return 2
+  # Many daemons don't delete their pidfiles when they exit.
+  rm -f $PIDFILE
+  return "$RETVAL"
+}
+
+do_reload() {
+  start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+  return 0
+}
+
+CMD="$1"
+shift
+if [ $# -gt 0 ] ; then
+  DAEMON_ARGS="$*"
+fi
+
+case "$CMD" in
+  start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+                0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+                2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+  stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+                0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+                2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+  status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+  reload|force-reload)
+        log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        log_end_msg $?
+        ;;
+  restart)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+                do_start
+                case "$?" in
+                        0) log_end_msg 0 ;;
+                        1) log_end_msg 1 ;; # Old process is still running
+                        *) log_end_msg 1 ;; # Failed to start
+                esac
+                ;;
+          *)
+                # Failed to stop
+                log_end_msg 1
+                ;;
+        esac
+        ;;
+  *)
+        echo "Usage: $SCRIPTNAME " >&2
+        exit 3
+        ;;
+esac
+
+:
+
+
+

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -176,6 +176,7 @@ if [ $INSTALLALL ]; then
     restore_database $WORKDIR/tmp.backup $PGDATABASE
     rm -f $WORKDIR/tmp.backup{,.md5sum}
     install_mwc $XTVERSION v$XTVERSION $INSTANCE false $PGDATABASE
+    setup_webprint
 fi
 
 # It is okay to run them both, but if either one runs we want to exit after as these

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -175,7 +175,7 @@ if [ $INSTALLALL ]; then
     download_demo auto $WORKDIR/tmp.backup $XTVERSION $DBTYPE
     restore_database $WORKDIR/tmp.backup $PGDATABASE
     rm -f $WORKDIR/tmp.backup{,.md5sum}
-    install_mwc $XTVERSION $INSTANCE false $PGDATABASE
+    install_mwc $XTVERSION v$XTVERSION $INSTANCE false $PGDATABASE
 fi
 
 # It is okay to run them both, but if either one runs we want to exit after as these


### PR DESCRIPTION
### Summary
Every time I would try to use xTAU in automated mode, it would upgrade the instance to 4.10b2. I found out this was because variable used in the 'git checkout' command is never instantiated in the function it is used, but rather in a function that calls that function.

### What I did:
1. Renamed MWCSTRING to MWCREFSPEC, as that's what it is used for.
2. Passing MWCREFSPEC to install_mwc as $2 (made the most sense to me anyway)
   * Adjusted arg references in install_mwc accordingly