### PR TITLE
removed qt-client option from provisioning menu

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -9,7 +9,6 @@ provision_menu() {
     "provisioncluster" "Provision PostgreSQL Cluster" ON \
     "initdb" "Add xTuple admin user and role" ON \
     "demodb" "Load xTuple Database" OFF \
-    "qtclient" "xTuple ERP Client" OFF \
     "webclient" "Load xTuple Web Client" OFF \
     "nginx" "Nginx" OFF \
     3>&1 1>&2 2>&3)
@@ -35,8 +34,6 @@ provision_menu() {
                       ;;
             "nginx") configure_nginx
                      ;;
-            "qt-client") msgbox "Qt Client not implemented yet"
-                         ;;
             "demodb") log_choice download_demo manual $WORKDIR/tmp.backup
                       ;;
             "webclient") log_choice install_mwc_menu


### PR DESCRIPTION
There is no need to have an option to install the qt-client on the provisioning menu. Currently, this option does nothing and it causes confusion to have it there, so I am removing it.