### PR TITLE
issue #31538 - fix problems installing nginx template

### DIFF
--- a/nginx.sh
+++ b/nginx.sh
@@ -111,13 +111,21 @@ type nginx >/dev/null 2>&1 || { echo >&2 "nginx not installed, installing"; inst
 #   NGINX_PORT      - nginx port to listen to
 configure_nginx() {
     echo "In: ${BASH_SOURCE} ${FUNCNAME[0]} $@"
+    NGINX_HOSTNAME="${1:-$NGINX_HOSTNAME}"
+    NGINX_SITE="${2:-$NGINX_DOMAIN}"
+    NGINX_SITE="${3:-$NGINX_SITE}"
+    NGINX_CERT="${4:-$NGINX_CERT}"
+    NGINX_KEY="${5:-$NGINX_KEY}"
+    NGINX_PORT="${6:-$NGINX_PORT}"
+
+    [ -n "$NGINX_SITE" ] || die The NGINX_SITE variable has not been set
 
     local CURRENTDIR=$(pwd)
 
     log "Configuring nginx"
 
     log "Removing nginx site default"
-    [[ -e /etc/nginx/sites-available/default ]] && sudo rm /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default 2>&1 >/dev/null
+    sudo rm -f /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
 
     log "Creating site file"
     cd "$WORKING"
@@ -131,7 +139,7 @@ configure_nginx() {
     fi
 
     log "Enabling site"
-    sudo ln -s /etc/nginx/sites-available/$NGINX_SITE /etc/nginx/sites-enabled/$NGINX_SITE
+    sudo ln --symbolic --force /etc/nginx/sites-available/$NGINX_SITE /etc/nginx/sites-enabled/$NGINX_SITE
 
     sudo mkdir -p /etc/xtuple/ssl
     RET=$?

--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -200,7 +200,7 @@ if [ $INSTALLALL ]; then
     install_mwc "$DBVERSION" "v$DBVERSION" "$MWCNAME" false "$DATABASE"
     install_nginx
     log_exec sudo mkdir -p /etc/xtuple/$DBVERSION/$MWCNAME/ssl/
-    configure_nginx "$NGINX_HOSTNAME" "$NGINX_DOMAIN" "$MWCNAME" true /etc/xtuple/$DBVERSION/$MWCNAME/ssl/server.{crt,key} 8443
+    configure_nginx "$NGINX_HOSTNAME" "$NGINX_DOMAIN" "$MWCNAME" /etc/xtuple/$DBVERSION/$MWCNAME/ssl/server.{crt,key} 8443
     setup_webprint
 fi
 


### PR DESCRIPTION
It looks like xdruple-server handles the `/etc/nginx/apps/drupal/drupal.conf` file. This PR fixes some more basic problems setting up the basic nginx configuration.