### PR TITLE
Fix: pass private extensions flag

### DIFF
--- a/xtuple-utility.sh
+++ b/xtuple-utility.sh
@@ -213,7 +213,7 @@ if [ $INSTALLALL ]; then
   install_xtuple_xvfb
 
   log_exec rm -f "$WORKDIR/tmp.backup{,.md5sum}"
-  install_webclient "v$DBVERSION" "v$DBVERSION" "$MWCNAME" false "$DATABASE"
+  install_webclient "v$DBVERSION" "v$DBVERSION" "$MWCNAME" $PRIVATEEXT "$DATABASE"
   install_nginx
   log_exec sudo mkdir --parents $CONFIGDIR/ssl
 


### PR DESCRIPTION
`$INSTALALL` installation sets `PRIVATEEXT` to true: https://github.com/xtuple/xtuple-admin-utility/blob/master/xtuple-utility.sh#L191 but doesn't pass it into `install_webclient`