### PR TITLE
Fix: ignore node_modules and xtuple_plv8 directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ sql/oa2client.sql
 backups/*.backup
 backups/*.sql
 xtau_config.json*
+node_modules
+xtuple_plv8


### PR DESCRIPTION
`node_modules` and `xtuple_plv8` directories end up in the `xtau` directory after `xtuple-utility.sh -a` run.

`node_modules` seem to be a result of `npm install bower` run, which previously was called inside `xtuple/xtuple` repo directory after `npm install`. `bower` installation doesn't seem to be required any more.
