### PR TITLE
Remove global PHARs installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.md5sum
 cleansockets.sh
 .already_ran_update
-phpunit.phar.1
 mwcbuild*/
 build.log
 xTupleCommerce*
@@ -18,7 +17,6 @@ private/*
 *.config
 sql/oa2client.sql
 *composer.phar*
-*phpunit.phar*
 backups/*.backup
 backups/*.sql
 xtau_config.json*

--- a/functions/setup.fun
+++ b/functions/setup.fun
@@ -948,20 +948,9 @@ php_setup() {
   sudo mv composer.phar /usr/local/bin/composer         || die
   sudo mkdir --parents /home/${DEPLOYER_NAME}/.composer || die
 
-  # PHPUnit (v6.x)
-  download https://phar.phpunit.de/phpunit.phar /usr/local/bin/phpunit +x
-
-  # PHP CodeSniffer
-  download https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar /usr/local/bin/phpcs +x
-
-  # PHP Code Beautifier
-  download https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar /usr/local/bin/phpcbf +x
-
-  # PHP Mess Detector
-  download http://static.phpmd.org/php/latest/phpmd.phar /usr/local/bin/phpmd +x
-
-  # Couscous (User documentation generation)
-  download http://couscous.io/couscous.phar /usr/local/bin/couscous +x
+  if [[ -f /home/"${DEPLOYER_NAME}"/.bashrc ]]; then
+    echo "export PATH=\"./vendor/bin:${PATH}\"" >> /home/"${DEPLOYER_NAME}"/.bashrc
+  fi
 
   # Restart PHP and Nginx
   sudo service php7.1-fpm restart

--- a/templates/zshrc.sh
+++ b/templates/zshrc.sh
@@ -54,7 +54,7 @@ plugins=(git)
 # User configuration
 
   export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
-  export PATH="/home/{DEPLOYER_NAME}/.composer/vendor/bin":$PATH
+  export PATH="./vendor/bin:/home/{DEPLOYER_NAME}/.composer/vendor/bin":$PATH
 # export MANPATH="/usr/local/man:$MANPATH"
   export COMPOSER_DISABLE_XDEBUG_WARN=1
 


### PR DESCRIPTION
PHP projects may require specific versions of PHPUnit, which might not be compatible with the globally installed one.
Using an executable installed by Composer for each project is more correct.